### PR TITLE
fix longitude_180 trouble (second edition)

### DIFF
--- a/lib/pr_geohash.rb
+++ b/lib/pr_geohash.rb
@@ -70,13 +70,19 @@ module GeoHash
       base = adjacent(base, dir)
     end
     base + BASE32[NEIGHBORS[dir][type].index(lastChr),1]
+  rescue TypeError => e
+    if geohash == ''
+      geohash
+    else
+      raise
+    end
   end
   module_function :adjacent
   
   
   BITS = [0x10, 0x08, 0x04, 0x02, 0x01]
   BASE32 = "0123456789bcdefghjkmnpqrstuvwxyz"
-  
+
   NEIGHBORS = {
     :right  => { :even => "bc01fg45238967deuvhjyznpkmstqrwx", :odd => "p0r21436x8zb9dcf5h7kjnmqesgutwvy" },
     :left   => { :even => "238967debc01fg45kmstqrwxuvhjyznp", :odd => "14365h7k9dcfesgujnmqp0r2twvyx8zb" },

--- a/lib/pr_geohash.rb
+++ b/lib/pr_geohash.rb
@@ -64,17 +64,15 @@ module GeoHash
   #########
   # Calculate adjacents geohash
   def adjacent(geohash, dir)
-    base, lastChr = geohash[0..-2], geohash[-1,1]
-    type = (geohash.length % 2)==1 ? :odd : :even
-    if BORDERS[dir][type].include?(lastChr)
-      base = adjacent(base, dir)
-    end
-    base + BASE32[NEIGHBORS[dir][type].index(lastChr),1]
-  rescue TypeError => e
     if geohash == ''
       geohash
     else
-      raise
+      base, lastChr = geohash[0..-2], geohash[-1,1]
+      type = (geohash.length % 2)==1 ? :odd : :even
+      if BORDERS[dir][type].include?(lastChr)
+        base = adjacent(base, dir)
+      end
+      base + BASE32[NEIGHBORS[dir][type].index(lastChr),1]
     end
   end
   module_function :adjacent


### PR DESCRIPTION
I check this code by run this:

```
(-90..90).each do |t|
  a = GeoHash.encode(t, 180, 12)
  b = GeoHash.adjacent(a, :right)
  raise if b != GeoHash.encode(t, -180, 12)
end
```

and

```
(-90..90).each do |t|
  a = GeoHash.encode(t, -180, 12)
  b = GeoHash.adjacent(a, :left)
  raise if b != GeoHash.encode(t, 180, 12)
end
```
