### PR TITLE
Fixed calculating adjacent geohashes when the length of the geohash i…

### DIFF
--- a/lib/pr_geohash.rb
+++ b/lib/pr_geohash.rb
@@ -64,6 +64,9 @@ module GeoHash
   #########
   # Calculate adjacents geohash
   def adjacent(geohash, dir)
+    if geohash.length == 1
+      return BASE32[NEIGHBORS[dir][:odd].index(geohash),1]
+    end
     base, lastChr = geohash[0..-2], geohash[-1,1]
     type = (geohash.length % 2)==1 ? :odd : :even
     if BORDERS[dir][type].include?(lastChr)
@@ -72,7 +75,6 @@ module GeoHash
     base + BASE32[NEIGHBORS[dir][type].index(lastChr),1]
   end
   module_function :adjacent
-  
   
   BITS = [0x10, 0x08, 0x04, 0x02, 0x01]
   BASE32 = "0123456789bcdefghjkmnpqrstuvwxyz"

--- a/test/test_pr_geohash.rb
+++ b/test/test_pr_geohash.rb
@@ -41,7 +41,33 @@ class PrGeoHashTests < Test::Unit::TestCase
       ["dqcjq", :top]    => 'dqcjw',
       ["dqcjq", :bottom] => 'dqcjn',
       ["dqcjq", :left]   => 'dqcjm',
-      ["dqcjq", :right]  => 'dqcjr'
+      ["dqcjq", :right]  => 'dqcjr',
+
+      ["r", :right]      => '2',
+      ["x", :right]      => '8',
+      ["g", :right]      => 'u',
+
+      ["2", :left]       => 'r',
+      ["8", :left]       => 'x',
+      ["u", :left]       => 'g',
+
+      ["e", :bottom]     => '7',
+      ["s", :bottom]     => 'k',
+
+      ["7", :top]        => 'e',
+      ["k", :top]        => 's',
+
+      ["rb", :right]     => '20',
+      ["rc", :right]     => '21',
+
+      ["20", :left]      => 'rb',
+      ["21", :left]      => 'rc',
+
+      ["d8", :bottom]    => '6x',
+      ["6x", :top]       => 'd8',
+
+      ["s20", :bottom]   => 'krb',
+      ["krb", :top]      => 's20',
     }.each do |position, hash|
       assert_equal GeoHash.adjacent(*position), hash
     end


### PR DESCRIPTION
Fixed calculating adjacent geohashes when the length of the geohash is <= 3 characters. Without the additional check, finding adjacent geohashes at borders (equator, international dateline, meridian, etc) resulted in an uncaught exception for geohashes < 3 characters. The tests that I added fail without the change in the adjacent(geohash, dir) module function.